### PR TITLE
Add title to graduation date

### DIFF
--- a/examples/json-schemas/education-certificate/JsonSchema2023-education-certificate.json
+++ b/examples/json-schemas/education-certificate/JsonSchema2023-education-certificate.json
@@ -26,6 +26,7 @@
                     "index": "1"
                 },
                 "graduationDate": {
+                    "title": "Graduation date",
                     "type": "string",
                     "format": "date-time",
                     "description": "Graduation date",


### PR DESCRIPTION
## Purpose
It was previously agreed that the `title` field was to be mandatory for each non `id` property. Graduation date is missing that field in the example.

## Changes
- Added missing title field.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.