### PR TITLE
Adapt concordia issuers to expected camel case serialized credential info

### DIFF
--- a/examples/some-issuer/Cargo.lock
+++ b/examples/some-issuer/Cargo.lock
@@ -613,7 +613,7 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "concordium-contracts-common"
-version = "7.1.0"
+version = "8.0.0"
 dependencies = [
  "base64 0.21.2",
  "bs58",
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common-derive"
-version = "3.0.0"
+version = "4.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -671,7 +671,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-smart-contract-engine"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -694,7 +694,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-wasm"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "concordium-contracts-common",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_base"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "aes",
  "anyhow",

--- a/examples/some-verifier/Cargo.lock
+++ b/examples/some-verifier/Cargo.lock
@@ -527,7 +527,7 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "concordium-contracts-common"
-version = "7.1.0"
+version = "8.0.0"
 dependencies = [
  "base64 0.21.2",
  "bs58",
@@ -547,7 +547,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common-derive"
-version = "3.0.0"
+version = "4.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-smart-contract-engine"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-wasm"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "concordium-contracts-common",
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_base"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "aes",
  "anyhow",

--- a/examples/some-verifier/frontend/src/components/Issuer.tsx
+++ b/examples/some-verifier/frontend/src/components/Issuer.tsx
@@ -144,10 +144,10 @@ interface IssueRequest {
 }
 
 interface CredentialInfo {
-  holder_id: string;
-  holder_revocable: boolean;
-  valid_from: string;
-  metadata_url: {
+  holderId: string;
+  holderRevocable: boolean;
+  validFrom: string;
+  metadataUrl: {
     url: string;
   };
 }
@@ -202,14 +202,14 @@ async function requestCredential(
   let txHash: string | undefined;
   await provider.addWeb3IdCredential(credential, metadataUrl, async (id) => {
     const parts = id.split(':');
-    const holder_id = parts[parts.length - 1];
+    const holderId = parts[parts.length - 1];
 
     const body: IssueRequest = {
       credential: {
-        holder_id,
-        holder_revocable: true,
-        valid_from: new Date().toISOString(),
-        metadata_url: metadataUrl,
+        holderId,
+        holderRevocable: true,
+        validFrom: new Date().toISOString(),
+        metadataUrl,
       },
     };
     if (req.platform === Platform.Telegram) body.telegramUser = req.user;


### PR DESCRIPTION
`CredentialInfo` from concordium-base has been updated to expect JSON with camel case properties. This PR:
- Updates the reference to the rust SDK, which includes the updated `CredentialInfo`
- Adapts the concordia verifier frontend to submit credential info in this format.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
