### PR TITLE
Fix credential schema url loading issues

### DIFF
--- a/test-tools/issuer-front-end/CHANGELOG.md
+++ b/test-tools/issuer-front-end/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## 1.0.2
 
-- Replace `http` with `https` in the schema metadata URL before fetching data.
 - Use `EXAMPLE_CREDENTIAL_SCHEMA` when associated input field is left empty in step 1.
 
 ## 1.0.1

--- a/test-tools/issuer-front-end/CHANGELOG.md
+++ b/test-tools/issuer-front-end/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased changes
 
+## 1.0.2
+
+- Replace `http` with `https` in the schema metadata URL before fetching data.
+- Use `EXAMPLE_CREDENTIAL_SCHEMA` when associated input field is left empty in step 1.
+
 ## 1.0.1
 
 - Make the issuer compatible with the latest 1.1.0 wallet.

--- a/test-tools/issuer-front-end/package.json
+++ b/test-tools/issuer-front-end/package.json
@@ -1,7 +1,7 @@
 {
     "name": "issuer-front-end",
     "packageManager": "yarn@3.2.0",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "license": "Apache-2.0",
     "engines": {
         "node": ">=16.x"

--- a/test-tools/issuer-front-end/src/Main.tsx
+++ b/test-tools/issuer-front-end/src/Main.tsx
@@ -529,8 +529,8 @@ export default function Main(props: WalletConnectionProps) {
                                             issuerMetaData,
                                             issuerKeys?.verifyKey || '',
                                             schemaCredentialURL.value === ''
-                                                ? JSON.stringify(exampleCredentialSchema)
-                                                : JSON.stringify(schemaCredential),
+                                                ? exampleCredentialSchema
+                                                : schemaCredential,
                                             JSON.stringify(revocationKeys),
                                             credentialType
                                         );

--- a/test-tools/issuer-front-end/src/Main.tsx
+++ b/test-tools/issuer-front-end/src/Main.tsx
@@ -186,10 +186,9 @@ export default function Main(props: WalletConnectionProps) {
             },
         });
 
+        const schemaURL = target.value.replace('http://', 'https://');
 
-        let schema_url = target.value.replace('http://', 'https://')
-
-        fetch(schema_url)
+        fetch(schemaURL)
             .then((response) => response.json())
             .then((json) => {
                 const { properties } = json.properties.credentialSubject.properties.attributes;
@@ -226,9 +225,12 @@ export default function Main(props: WalletConnectionProps) {
 
             const registryMetadataReturnValue = JSON.parse(await registryMetadata(client, Number(target.value)));
 
-            let schema_url = registryMetadataReturnValue.credential_schema.schema_ref.url.replace('http://', 'https://')
+            const schemaURL = registryMetadataReturnValue.credential_schema.schema_ref.url.replace(
+                'http://',
+                'https://'
+            );
 
-            fetch(schema_url)
+            fetch(schemaURL)
                 .then((response) => response.json())
                 .then((json) => {
                     const { properties } = json.properties.credentialSubject.properties.attributes;
@@ -508,23 +510,27 @@ export default function Main(props: WalletConnectionProps) {
                                         setTxHash('');
                                         setTransactionError('');
 
-                                        const schemaCredentialURL = document.getElementById("credentialSchemaURL") as unknown as HTMLFormElement;
+                                        const schemaCredentialURL = document.getElementById(
+                                            'credentialSchemaURL'
+                                        ) as unknown as HTMLFormElement;
 
-                                        let exampleCredentialSchema = {
+                                        const exampleCredentialSchema = {
                                             schema_ref: {
                                                 hash: {
                                                     None: [],
                                                 },
                                                 url: EXAMPLE_CREDENTIAL_SCHEMA,
-                                            }
-                                        }
+                                            },
+                                        };
 
                                         const tx = createNewIssuer(
                                             connection,
                                             account,
                                             issuerMetaData,
                                             issuerKeys?.verifyKey || '',
-                                            schemaCredentialURL.value == '' ? JSON.stringify(exampleCredentialSchema) : JSON.stringify(schemaCredential),
+                                            schemaCredentialURL.value === ''
+                                                ? JSON.stringify(exampleCredentialSchema)
+                                                : JSON.stringify(schemaCredential),
                                             JSON.stringify(revocationKeys),
                                             credentialType
                                         );

--- a/test-tools/issuer-front-end/src/Main.tsx
+++ b/test-tools/issuer-front-end/src/Main.tsx
@@ -186,7 +186,7 @@ export default function Main(props: WalletConnectionProps) {
             },
         });
 
-        const schemaURL = target.value.replace('http://', 'https://');
+        const schemaURL = target.value;
 
         fetch(schemaURL)
             .then((response) => response.json())
@@ -225,10 +225,7 @@ export default function Main(props: WalletConnectionProps) {
 
             const registryMetadataReturnValue = JSON.parse(await registryMetadata(client, Number(target.value)));
 
-            const schemaURL = registryMetadataReturnValue.credential_schema.schema_ref.url.replace(
-                'http://',
-                'https://'
-            );
+            const schemaURL = registryMetadataReturnValue.credential_schema.schema_ref.url;
 
             fetch(schemaURL)
                 .then((response) => response.json())

--- a/test-tools/issuer-front-end/src/Main.tsx
+++ b/test-tools/issuer-front-end/src/Main.tsx
@@ -225,6 +225,8 @@ export default function Main(props: WalletConnectionProps) {
 
             const registryMetadataReturnValue = JSON.parse(await registryMetadata(client, Number(target.value)));
 
+            setSchemaCredential(registryMetadataReturnValue.credential_schema);
+
             const schemaURL = registryMetadataReturnValue.credential_schema.schema_ref.url;
 
             fetch(schemaURL)

--- a/test-tools/issuer-front-end/src/Main.tsx
+++ b/test-tools/issuer-front-end/src/Main.tsx
@@ -186,7 +186,10 @@ export default function Main(props: WalletConnectionProps) {
             },
         });
 
-        fetch(target.value)
+
+        let schema_url = target.value.replace('http://', 'https://')
+
+        fetch(schema_url)
             .then((response) => response.json())
             .then((json) => {
                 const { properties } = json.properties.credentialSubject.properties.attributes;
@@ -223,9 +226,9 @@ export default function Main(props: WalletConnectionProps) {
 
             const registryMetadataReturnValue = JSON.parse(await registryMetadata(client, Number(target.value)));
 
-            setSchemaCredential(registryMetadataReturnValue.credential_schema);
+            let schema_url = registryMetadataReturnValue.credential_schema.schema_ref.url.replace('http://', 'https://')
 
-            fetch(registryMetadataReturnValue.credential_schema.schema_ref.url)
+            fetch(schema_url)
                 .then((response) => response.json())
                 .then((json) => {
                     const { properties } = json.properties.credentialSubject.properties.attributes;
@@ -504,12 +507,24 @@ export default function Main(props: WalletConnectionProps) {
                                     onClick={() => {
                                         setTxHash('');
                                         setTransactionError('');
+
+                                        const schemaCredentialURL = document.getElementById("credentialSchemaURL") as unknown as HTMLFormElement;
+
+                                        let exampleCredentialSchema = {
+                                            schema_ref: {
+                                                hash: {
+                                                    None: [],
+                                                },
+                                                url: EXAMPLE_CREDENTIAL_SCHEMA,
+                                            }
+                                        }
+
                                         const tx = createNewIssuer(
                                             connection,
                                             account,
                                             issuerMetaData,
                                             issuerKeys?.verifyKey || '',
-                                            JSON.stringify(schemaCredential),
+                                            schemaCredentialURL.value == '' ? JSON.stringify(exampleCredentialSchema) : JSON.stringify(schemaCredential),
                                             JSON.stringify(revocationKeys),
                                             credentialType
                                         );

--- a/test-tools/issuer-front-end/src/writing_to_blockchain.ts
+++ b/test-tools/issuer-front-end/src/writing_to_blockchain.ts
@@ -21,7 +21,7 @@ export async function createNewIssuer(
     account: string,
     issuerMetaData: string,
     issuerKey: string,
-    schemaCredential: string,
+    schemaCredential: object,
     revocationKeys: string,
     credentialType: string
 ) {
@@ -37,10 +37,6 @@ export async function createNewIssuer(
         throw new Error(`Set credentialType`);
     }
 
-    if (schemaCredential === '') {
-        throw new Error(`Set credentialSchemaURL`);
-    }
-
     const parameter = {
         issuer_metadata: {
             hash: {
@@ -52,7 +48,7 @@ export async function createNewIssuer(
             credential_type: credentialType,
         },
         issuer_key: issuerKey,
-        schema: JSON.parse(schemaCredential),
+        schema: schemaCredential,
         issuer_account: {
             Some: [account],
         },


### PR DESCRIPTION
## Purpose

- Use `EXAMPLE_CREDENTIAL_SCHEMA` when the associated input field is left empty in step 1.

https://concordium.atlassian.net/browse/CBW-1272

## Changes

- Use `EXAMPLE_CREDENTIAL_SCHEMA` when the associated input field is left empty in step 1.
