### PR TITLE
Bump dependencies and versions.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 .*
 **/target
+
+**/node_modules

--- a/services/web3id-issuer/CHANGELOG.md
+++ b/services/web3id-issuer/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1
+
+- Fix date-time attribute support by changing epoch to `-262144-01-01T00:00:00Z` from Unix epoch.
+
 ## 0.3.0
 
 - Support date-time attributes.

--- a/services/web3id-issuer/Cargo.lock
+++ b/services/web3id-issuer/Cargo.lock
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-rust-sdk"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_base"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "aes",
  "anyhow",

--- a/services/web3id-issuer/Cargo.toml
+++ b/services/web3id-issuer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web3id-issuer"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/services/web3id-verifier/CHANGELOG.md
+++ b/services/web3id-verifier/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1
+
+- Fix date-time attribute support by changing epoch to `-262144-01-01T00:00:00Z` from Unix epoch.
+
 ## 0.4.0
 
 - Support date-time attributes.

--- a/services/web3id-verifier/Cargo.lock
+++ b/services/web3id-verifier/Cargo.lock
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-rust-sdk"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_base"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "aes",
  "anyhow",
@@ -2975,7 +2975,7 @@ dependencies = [
 
 [[package]]
 name = "web3id-verifier"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/services/web3id-verifier/Cargo.toml
+++ b/services/web3id-verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web3id-verifier"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/test-tools/issuer-front-end/backend/Cargo.lock
+++ b/test-tools/issuer-front-end/backend/Cargo.lock
@@ -546,7 +546,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-rust-sdk"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_base"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "aes",
  "anyhow",

--- a/test-tools/proof-explorer/CHANGELOG.md
+++ b/test-tools/proof-explorer/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased changes.
 
+## 1.0.1
+
+Rename `outer` statement to `credential` statement.
+
 ## 1.0.0
 
 Initial version.

--- a/test-tools/proof-explorer/package.json
+++ b/test-tools/proof-explorer/package.json
@@ -1,7 +1,7 @@
 {
     "name": "proof-explorer",
     "license": "Apache-2.0",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "packageManager": "yarn@3.2.0",
     "dependencies": {
         "@concordium/browser-wallet-api-helpers": "file:../../deps/concordium-browser-wallet/packages/browser-wallet-api-helpers",

--- a/test-tools/web3id-test/Cargo.lock
+++ b/test-tools/web3id-test/Cargo.lock
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-rust-sdk"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -641,7 +641,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_base"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "aes",
  "anyhow",
@@ -1480,7 +1480,7 @@ dependencies = [
 
 [[package]]
 name = "key_derivation"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "concordium_base",
  "ed25519-dalek",
@@ -2648,6 +2648,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2852,6 +2861,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys",
@@ -3301,7 +3311,7 @@ dependencies = [
 
 [[package]]
 name = "web3id-issuer"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3309,6 +3319,7 @@ dependencies = [
  "chrono",
  "clap",
  "concordium-rust-sdk",
+ "futures",
  "rand 0.7.3",
  "serde",
  "serde_json",


### PR DESCRIPTION
## Purpose

Update Rust SDK to fix the timestamp parsing, changing the epoch from Unix epoch to UTC_MIN.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.