### PR TITLE
Fix credential loading

### DIFF
--- a/test-tools/issuer-front-end/CHANGELOG.md
+++ b/test-tools/issuer-front-end/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased changes
 
+## 1.0.6
+
+- Use credentialType and credentialSchema fetched from the smart contract instance.
+
 ## 1.0.5
 
 - Add support for optional attributes.

--- a/test-tools/issuer-front-end/package.json
+++ b/test-tools/issuer-front-end/package.json
@@ -1,7 +1,7 @@
 {
     "name": "issuer-front-end",
     "packageManager": "yarn@3.2.0",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "license": "Apache-2.0",
     "engines": {
         "node": ">=16.x"


### PR DESCRIPTION
## Purpose

https://concordium.slack.com/archives/C055CBEDJSD/p1693224768172119

- Use credentialSchema/credentialType that is fetched from the smart contract instance when issuing a credential.

## Changes

- Use credentialSchema/credentialType that is fetched from the smart contract instance.
- Provide one negative scenario where the tester can use a different credentialSchema/credentialType to test how the wallet reacts.