### PR TITLE
Remove title and description for the `attributes` attribute

### DIFF
--- a/examples/json-schemas/education-certificate/JsonSchema2023-education-certificate.json
+++ b/examples/json-schemas/education-certificate/JsonSchema2023-education-certificate.json
@@ -14,8 +14,6 @@
                     "description": "Credential subject identifier"
                 },
                 "attributes": {
-                    "title": "Attributes",
-                    "description": "Credential attributes",
                     "type": "object",
                     "properties": {
                         "degreeType": {


### PR DESCRIPTION
## Purpose

The `attributes` attribute is an object that groups all the credential attributes together; `title` and `description` for it should be optional. To avoid confusion, these fields are removed from the example schema.
