### PR TITLE
Support integer type in JSON schema.

### DIFF
--- a/services/web3id-issuer/Cargo.lock
+++ b/services/web3id-issuer/Cargo.lock
@@ -2975,7 +2975,7 @@ dependencies = [
 
 [[package]]
 name = "web3id-issuer"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/test-tools/issuer-front-end/CHANGELOG.md
+++ b/test-tools/issuer-front-end/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.9
 
 - Change to use a hexString for the auxiliary data.
+- Support 'integer' type in the schema.
 
 ## 1.0.8
 

--- a/test-tools/issuer-front-end/src/Main.tsx
+++ b/test-tools/issuer-front-end/src/Main.tsx
@@ -88,7 +88,7 @@ function attributeInputPlaceHolder(details: AttributeDetails): string {
     if (details.type === 'date-time') {
         return '2023-08-30T06:22:46Z';
     }
-    if (details.type === 'number') {
+    if (details.type === 'number' || details.type === 'integer') {
         return '1234';
     }
     return 'myString';
@@ -181,7 +181,7 @@ function parseAttributesFromForm(
         } else if (obj.value !== undefined) {
             if (obj.type === 'string') {
                 attributes[obj.tag] = obj.value;
-            } else if (obj.type === 'number') {
+            } else if (obj.type === 'number' || obj.type == 'integer') {
                 attributes[obj.tag] = BigInt(obj.value);
             } else if (obj.type === 'date-time') {
                 const date = new Date(obj.value.trim());
@@ -193,10 +193,10 @@ function parseAttributesFromForm(
                 attributes[obj.tag] = date;
             } else {
                 setParsingError(
-                    `Attribute ${obj.tag} has type ${obj.type}. Only the types string/number and date-time are supported.`
+                    `Attribute ${obj.tag} has type ${obj.type}. Only the types string/number/integer and date-time are supported.`
                 );
                 throw new Error(
-                    `Attribute ${obj.tag} has type ${obj.type}. Only the types string/number and date-time are supported.`
+                    `Attribute ${obj.tag} has type ${obj.type}. Only the types string/number/integer and date-time are supported.`
                 );
             }
         }

--- a/test-tools/issuer-front-end/src/constants.ts
+++ b/test-tools/issuer-front-end/src/constants.ts
@@ -1,7 +1,7 @@
 import { BrowserWalletConnector, ephemeralConnectorType } from '@concordium/react-components';
 import moment from 'moment';
 
-export const EXAMPLE_CREDENTIAL_SCHEMA = 'https://raw.githubusercontent.com/Concordium/concordium-web3id/main/examples/json-schemas/education-certificate/JsonSchema2023-education-certificate.json';
+export const EXAMPLE_CREDENTIAL_SCHEMA = 'https://raw.githubusercontent.com/Concordium/concordium-web3id/522248d445cea0362f2c8f40c2a64a794f39b2c9/examples/json-schemas/education-certificate/JsonSchema2023-education-certificate.json';
 
 export const EXAMPLE_CREDENTIAL_METADATA = `https://gist.githubusercontent.com/abizjak/ff1e90d82c5446c0e001ee6d4e33ea6b/raw/4528363aff42e3ff36b50a1d873287f2f520d610/metadata.json`;
 

--- a/test-tools/issuer-front-end/src/constants.ts
+++ b/test-tools/issuer-front-end/src/constants.ts
@@ -1,7 +1,7 @@
 import { BrowserWalletConnector, ephemeralConnectorType } from '@concordium/react-components';
 import moment from 'moment';
 
-export const EXAMPLE_CREDENTIAL_SCHEMA = `https://raw.githubusercontent.com/Concordium/concordium-web3id/ac803895b1ffaa50888cfc6667331f6ebb0b889e/examples/json-schemas/education-certificate/JsonSchema2023-education-certificate.json`;
+export const EXAMPLE_CREDENTIAL_SCHEMA = 'https://raw.githubusercontent.com/Concordium/concordium-web3id/main/examples/json-schemas/education-certificate/JsonSchema2023-education-certificate.json';
 
 export const EXAMPLE_CREDENTIAL_METADATA = `https://gist.githubusercontent.com/abizjak/ff1e90d82c5446c0e001ee6d4e33ea6b/raw/4528363aff42e3ff36b50a1d873287f2f520d610/metadata.json`;
 

--- a/test-tools/proof-explorer/CHANGELOG.md
+++ b/test-tools/proof-explorer/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased changes.
 
+## 1.0.3
+
+Support 'integer' type in the schema.
+
 ## 1.0.2
 
 Add support for date-time attributes.

--- a/test-tools/proof-explorer/package.json
+++ b/test-tools/proof-explorer/package.json
@@ -1,7 +1,7 @@
 {
     "name": "proof-explorer",
     "license": "Apache-2.0",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "packageManager": "yarn@3.2.0",
     "dependencies": {
         "@concordium/browser-wallet-api-helpers": "2.6.0",

--- a/test-tools/proof-explorer/src/Root.tsx
+++ b/test-tools/proof-explorer/src/Root.tsx
@@ -416,13 +416,13 @@ function AttributeInRange({ setStatement, attributeOptions }: RevealAttributePro
 
     const onClickAdd: MouseEventHandler<HTMLButtonElement> = () => {
         let lower_bound = lower[0];
-        if (lower[1] == 'number') {
+        if (lower[1] === 'number' || lower[1] === 'integer') {
             lower_bound = BigInt(lower[0]);
         } else if (lower[1] == 'date-time') {
             lower_bound = new Date(lower[0].trim());
         }
         let upper_bound = upper[0];
-        if (upper[1] == 'number') {
+        if (upper[1] === 'number' || upper[1] === 'integer') {
             upper_bound = BigInt(upper[0]);
         } else if (upper[1] == 'date-time') {
             upper_bound = new Date(upper[0].trim());
@@ -488,7 +488,7 @@ function AttributeInSet({ member, setStatement, attributeOptions }: SetMembershi
     };
 
     let proof_set = set.split(',').map((s) => s.trim());
-    if (selected[1] == 'number') {
+    if (selected[1] === 'number' || selected[1] === 'integer') {
         proof_set = proof_set.map((x) => BigInt(x));
     } else if (selected[1] == 'date-time') {
         proof_set = proof_set.map((x) => new Date(x.trim()));


### PR DESCRIPTION
## Purpose

Support `integer` type in JSON schema.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.