### PR TITLE
Fix state synchronization bug

### DIFF
--- a/services/web3id-issuer/CHANGELOG.md
+++ b/services/web3id-issuer/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased changes
+
+- Fixed a bug where the state of the server could become inconsistent if a client cancelled a request while the server was waiting for repsonse from the node.
+
 ## 0.3.1
 
 - Fix date-time attribute support by changing epoch to `-262144-01-01T00:00:00Z` from Unix epoch.

--- a/services/web3id-issuer/src/main.rs
+++ b/services/web3id-issuer/src/main.rs
@@ -403,7 +403,7 @@ async fn issue_credential(
     };
 
     let (response_sender, response_receiver) = tokio::sync::oneshot::channel();
-    // Ask the issuer wormer to send the transaction.
+    // Ask the issuer worker to send the transaction.
     if state
         .sender
         .send(IssueChannelData {
@@ -467,7 +467,10 @@ async fn main() -> anyhow::Result<()> {
         app.endpoint
     }
     .connect_timeout(std::time::Duration::from_secs(10))
-    .timeout(std::time::Duration::from_millis(app.request_timeout));
+    .timeout(std::time::Duration::from_millis(app.request_timeout))
+    .http2_keep_alive_interval(std::time::Duration::from_secs(300))
+    .keep_alive_timeout(std::time::Duration::from_secs(10))
+    .keep_alive_while_idle(true);
 
     let mut client = v2::Client::new(endpoint)
         .await


### PR DESCRIPTION
## Purpose

Addresses #123.

## Changes

The responsibility for sending transactions to the chain and updating the state (i.e. nonce) is moved to a separate worker thread that continues running, even when a connection is cancelled. The worker submits the transaction, updates the state, and sends the transaction hash back to the request handler.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
