### PR TITLE
Enable wallet connect

### DIFF
--- a/test-tools/proof-explorer/CHANGELOG.md
+++ b/test-tools/proof-explorer/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased changes.
 
+## 1.1.0
+
+Add button for connecting to mobile wallets using WalletConnect.
+
 ## 1.0.6
 
 -   Upgrade frontend dependencies @concordium/web-sdk and @concordium/browser-wallet-api-helpers

--- a/test-tools/proof-explorer/README.md
+++ b/test-tools/proof-explorer/README.md
@@ -2,17 +2,14 @@
 
 ### Build
 
-This is a typescript project. You need `yarn` to build it. To build first build
-the `browser-wallet-api-helpers` dependency by running
+This is a typescript project. You need `yarn` to build it. To install dependencies run:
 
 ```
-yarn install && yarn build:api-helpers
+yarn install
 ```
-from `../../deps/concordium-browser-wallet/`
 
 After that run
 ```
-yarn install
 yarn build
 ```
 
@@ -23,10 +20,8 @@ By default it uses https://web3id-verifier.testnet.concordium.com
 
 ### Development
 
-Use `yarn watch` to automatically rebuild upon changes.
+Use `yarn dev` to serve the pages locally.
 Use `yarn lint` to check formatting and common issues. Use `yarn lint-and-fix` to automatically fix a number of issues (e.g., formatting).
-Use `yarn start` to serve the pages locally.
-
 
 ## Docker image
 

--- a/test-tools/proof-explorer/package.json
+++ b/test-tools/proof-explorer/package.json
@@ -1,7 +1,7 @@
 {
     "name": "proof-explorer",
     "license": "Apache-2.0",
-    "version": "1.0.6",
+    "version": "1.1.0",
     "packageManager": "yarn@4.0.1",
     "dependencies": {
         "@concordium/browser-wallet-api-helpers": "^3.0.0",

--- a/test-tools/proof-explorer/package.json
+++ b/test-tools/proof-explorer/package.json
@@ -10,11 +10,13 @@
         "@walletconnect/sign-client": "^2.1.5",
         "@walletconnect/types": "^2.1.5",
         "buffer": "^6.0.3",
+        "json-bigint": "^1.0.0",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
         "react-select": "^5.7.0"
     },
     "devDependencies": {
+        "@types/json-bigint": "^1",
         "@types/node": "^18.11.14",
         "@types/react": "^18.0.9",
         "@types/react-dom": "^18.0.5",

--- a/test-tools/proof-explorer/src/Root.tsx
+++ b/test-tools/proof-explorer/src/Root.tsx
@@ -1052,20 +1052,17 @@ export default function ProofExplorer() {
                             >
                                 Connect browser
                             </button>
+                            <button
+                                className="btn btn-secondary mt-2"
+                                onClick={async () => connectProvider(await WalletConnectProvider.getInstance())}
+                            >
+                                Connect mobile
+                            </button>
                         </div>
                         {provider !== undefined && <div className="col-4 bg-info p-2 text-center"> Connected </div>}
                         {provider === undefined && (
                             <div className="col-4 bg-danger p-2 text-center"> Not connected </div>
                         )}
-                        {
-                            // This is commented out since the mobile wallets don't support Web3ID proofs at the moment.
-                            <button
-                                className="btn btn-secondary"
-                                onClick={async () => connectProvider(await WalletConnectProvider.getInstance())}
-                            >
-                                Connect mobile
-                            </button>
-                        }
                     </div>
                     <hr />
                     <div className="row">

--- a/test-tools/proof-explorer/src/Root.tsx
+++ b/test-tools/proof-explorer/src/Root.tsx
@@ -21,7 +21,7 @@ import {
     EntrypointName,
 } from '@concordium/web-sdk';
 import { Buffer } from 'buffer';
-import { BrowserWalletProvider, WalletProvider } from './wallet-connection';
+import { BrowserWalletProvider, WalletConnectProvider, WalletProvider } from './wallet-connection';
 import { GrpcWebFetchTransport } from '@protobuf-ts/grpcweb-transport';
 import { VERIFIER_URL, GRPC_WEB_CONFIG, REGISTRY_CONTRACT_REGISTRY_METADATA_RETURN_VALUE_SCHEMA } from './constants';
 import { version } from '../package.json';
@@ -211,12 +211,13 @@ async function submitProof(
         return;
     }
     console.log(proof.toString());
+    console.log(proof);
     const resp = await fetch(`${getVerifierURL()}/v0/verify`, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
         },
-        body: proof.toString(),
+        body: JSON.stringify(proof),
     });
     if (resp.ok) {
         setMessages((oldMessages) => [...oldMessages, 'Proof OK']);
@@ -1058,13 +1059,12 @@ export default function ProofExplorer() {
                         )}
                         {
                             // This is commented out since the mobile wallets don't support Web3ID proofs at the moment.
-                            // <button
-                            //     className="btn btn-secondary"
-                            //     disabled
-                            //     onClick={async () => connectProvider(await WalletConnectProvider.getInstance())}
-                            // >
-                            //     Connect mobile
-                            // </button>
+                            <button
+                                className="btn btn-secondary"
+                                onClick={async () => connectProvider(await WalletConnectProvider.getInstance())}
+                            >
+                                Connect mobile
+                            </button>
                         }
                     </div>
                     <hr />

--- a/test-tools/proof-explorer/src/Root.tsx
+++ b/test-tools/proof-explorer/src/Root.tsx
@@ -217,7 +217,7 @@ async function submitProof(
         headers: {
             'Content-Type': 'application/json',
         },
-        body: JSON.stringify(proof),
+        body: proof.toString(),
     });
     if (resp.ok) {
         setMessages((oldMessages) => [...oldMessages, 'Proof OK']);

--- a/test-tools/proof-explorer/src/wallet-connection.tsx
+++ b/test-tools/proof-explorer/src/wallet-connection.tsx
@@ -80,7 +80,7 @@ export class BrowserWalletProvider extends WalletProvider {
     }
 }
 
-const ID_METHOD = 'proof_of_identity';
+const ID_METHOD = 'request_verifiable_presentation';
 
 let walletConnectInstance: WalletConnectProvider | undefined;
 

--- a/test-tools/proof-explorer/src/wallet-connection.tsx
+++ b/test-tools/proof-explorer/src/wallet-connection.tsx
@@ -169,16 +169,15 @@ export class WalletConnectProvider extends WalletProvider {
         };
 
         try {
-            const verifiablePresentation = (await this.client.request({
+            const result = (await this.client.request<{ verifiablePresentationJson: string }>({
                 topic: this.topic,
                 request: {
                     method: ID_METHOD,
                     params,
                 },
                 chainId: CHAIN_ID,
-            })) as VerifiablePresentation;
-
-            return verifiablePresentation;
+            }));
+            return VerifiablePresentation.fromString(result.verifiablePresentationJson);
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } catch (e: any) {
             if (isWalletConnectError(e)) {

--- a/test-tools/proof-explorer/src/wallet-connection.tsx
+++ b/test-tools/proof-explorer/src/wallet-connection.tsx
@@ -165,20 +165,20 @@ export class WalletConnectProvider extends WalletProvider {
 
         const params = {
             challenge,
-            statement,
+            credentialStatements: statement,
         };
 
         try {
-            const { idProof } = (await this.client.request({
+            const verifiablePresentation = (await this.client.request({
                 topic: this.topic,
                 request: {
                     method: ID_METHOD,
                     params,
                 },
                 chainId: CHAIN_ID,
-            })) as { idProof: VerifiablePresentation };
+            })) as VerifiablePresentation;
 
-            return idProof;
+            return verifiablePresentation;
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } catch (e: any) {
             if (isWalletConnectError(e)) {

--- a/test-tools/proof-explorer/src/wallet-connection.tsx
+++ b/test-tools/proof-explorer/src/wallet-connection.tsx
@@ -4,6 +4,7 @@ import { SessionTypes, SignClientTypes } from '@walletconnect/types';
 import SignClient from '@walletconnect/sign-client';
 import QRCodeModal from '@walletconnect/qrcode-modal';
 import EventEmitter from 'events';
+import JSONBigInt from 'json-bigint';
 
 const WALLET_CONNECT_PROJECT_ID = '76324905a70fe5c388bab46d3e0564dc';
 const WALLET_CONNECT_SESSION_NAMESPACE = 'ccd';
@@ -168,15 +169,17 @@ export class WalletConnectProvider extends WalletProvider {
             credentialStatements: statement,
         };
 
+        const serializedParams = JSONBigInt.stringify(params);
+
         try {
-            const result = (await this.client.request<{ verifiablePresentationJson: string }>({
+            const result = await this.client.request<{ verifiablePresentationJson: string }>({
                 topic: this.topic,
                 request: {
                     method: ID_METHOD,
-                    params,
+                    params: { paramsJson: serializedParams },
                 },
                 chainId: CHAIN_ID,
-            }));
+            });
             return VerifiablePresentation.fromString(result.verifiablePresentationJson);
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } catch (e: any) {

--- a/test-tools/proof-explorer/yarn.lock
+++ b/test-tools/proof-explorer/yarn.lock
@@ -1103,6 +1103,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/json-bigint@npm:^1":
+  version: 1.0.4
+  resolution: "@types/json-bigint@npm:1.0.4"
+  checksum: bb567bac8d64f541abb3cb716d5c699c460b9aa4a9fc5fc81a3cee9cb57fe8c03914022049dcdadff213972979a5d08267405d55d2ed6aa95d3558f08347008a
+  languageName: node
+  linkType: hard
+
 "@types/json-schema@npm:^7.0.9":
   version: 7.0.12
   resolution: "@types/json-schema@npm:7.0.12"
@@ -4824,6 +4831,7 @@ __metadata:
   dependencies:
     "@concordium/browser-wallet-api-helpers": "npm:^3.0.0"
     "@concordium/web-sdk": "npm:^7.1.0"
+    "@types/json-bigint": "npm:^1"
     "@types/node": "npm:^18.11.14"
     "@types/react": "npm:^18.0.9"
     "@types/react-dom": "npm:^18.0.5"
@@ -4839,6 +4847,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^4.0.0"
     eslint-plugin-react: "npm:^7.29.4"
     eslint-plugin-react-hooks: "npm:^4.4.0"
+    json-bigint: "npm:^1.0.0"
     prettier: "npm:^2.6.2"
     react: "npm:^18.1.0"
     react-dom: "npm:^18.1.0"


### PR DESCRIPTION
## Purpose
Enables WalletConnect for the proof-explorer. This builds on the commented code that was already present and just makes adjustments to enable it.

## Changes
- Changed the ID_METHOD name to the agreed naming convention.
- Added a connect button for mobile (WalletConnect).

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.